### PR TITLE
Fixed bug in FragBundler with intents

### DIFF
--- a/DBAndroid/app/src/main/java/ses1grp6/dbsystemandroid/charity/EditListingFragment.java
+++ b/DBAndroid/app/src/main/java/ses1grp6/dbsystemandroid/charity/EditListingFragment.java
@@ -30,7 +30,7 @@ import ses1grp6.dbsystemandroid.util.SimpleRecyclerAdaptor;
 
 public class EditListingFragment extends Fragment {
 
-    private List<Application> applications;
+    private List<Application> applications = new ArrayList<>();
     private Listing listing;
     private SimpleRecyclerAdaptor<ApplicationHolder, Application> adaptor;
     private RecyclerView recyclerView;
@@ -43,8 +43,8 @@ public class EditListingFragment extends Fragment {
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_edit_listing, container, false);
         recyclerView = view.findViewById(R.id.applicantsRecyclerView);
-        FragBundler bundler = new FragBundler(getActivity().getIntent());
-        listing = bundler.getModel();
+        Intent intent = getActivity().getIntent();
+        listing = Listing.getFromIntent(intent);
         fetchApplicants();
         buildRecyclerView();
         return view;

--- a/DBAndroid/app/src/main/java/ses1grp6/dbsystemandroid/util/FragBundler.java
+++ b/DBAndroid/app/src/main/java/ses1grp6/dbsystemandroid/util/FragBundler.java
@@ -16,7 +16,6 @@ import ses1grp6.dbsystemandroid.R;
 public class FragBundler {
 
     private static final String INTENT_FRAG_NAME = "dynamicFragment";
-    private static final String INTENT_FRAG_MODEL = "dynamicFragmentModel";
     private Intent intent;
 
     public FragBundler(Intent intent) {
@@ -25,11 +24,6 @@ public class FragBundler {
 
     public void putToIntent(Class<? extends Fragment> fragClz) {
         intent.putExtra(INTENT_FRAG_NAME, fragClz.getName());
-    }
-
-    public <M extends Parcelable> void putToIntent(Class<? extends Fragment> fragClz, M model) {
-        putToIntent(fragClz);
-        intent.putExtra(INTENT_FRAG_MODEL, model);
     }
 
     public Class<? extends Fragment> getFragmentClass() {
@@ -44,16 +38,6 @@ public class FragBundler {
 
     public boolean hasFragment() {
         return intent.hasExtra(INTENT_FRAG_NAME);
-    }
-
-    public boolean hasModel() {
-        return intent.hasExtra(INTENT_FRAG_MODEL);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <M extends Parcelable> M getModel() {
-        if (!hasModel()) throw new RuntimeException("Could not find model in intent");
-        return (M) intent.getParcelableExtra(INTENT_FRAG_MODEL);
     }
 
     public Fragment getFragment() {


### PR DESCRIPTION
Fixed the issue that FragBundler and models had two different keys for storing the actual models in intent. Now they are consistent to only use the key in model. FragBundler does handle the storing of models.